### PR TITLE
Remove first login script for root user

### DIFF
--- a/tools/build-image.py
+++ b/tools/build-image.py
@@ -56,7 +56,7 @@ commands = [
     "rm -rf /var/log/*.log",
     "curl https://raw.githubusercontent.com/meilisearch/meilisearch-cloud/main/scripts/deploy-meilisearch.sh | bash",
     "curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash",
-    'echo "sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh" >> /root/.bashrc && curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash',
+    "curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash",
 ]
 
 for cmd in commands:


### PR DESCRIPTION
Since https://github.com/meilisearch/meilisearch-cloud/pull/2 the Droplet configuration is done with the `root` user, but the end user should access the droplet with a custom user called `meilisearch` that will launch the first login configuration scripts. Root shouldn't run this script automatically, as this may block other configuration scripts and instructions.