### PR TITLE
Fix: Missing 'time' reference

### DIFF
--- a/tools/do_meili_tools.py
+++ b/tools/do_meili_tools.py
@@ -55,5 +55,5 @@ def wait_for_snapshot_creation(droplet):
                 return
         except Exception as e:
             print("   Exception: {}".format(e))
-            sleep(300)
+            time.sleep(300)
             return


### PR DESCRIPTION
Missing time reference leading to interpreter Exception while waiting for Snapshot creation