### PR TITLE
Remove ssh commands and add cloud-config in USER_DATA

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -30,14 +30,6 @@ print('Waiting for Health check (may take a few minutes: config and reboot)')
 wait_for_health_check(droplet)
 print('   Instance is healthy')
 
-commands = [
-    'rm -rf /var/log/*.log',
-    'curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | bash -s {0}'.format(
-        conf.MEILI_CLOUD_SCRIPTS_VERSION_TAG),
-    'curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash',
-    'curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash',
-]
-
 # Power down Droplet
 
 print('Powering down droplet...')

--- a/tools/config.py
+++ b/tools/config.py
@@ -14,8 +14,9 @@ SNAPSHOT_NAME = 'MeiliSearch-{}-Debian-10.3'.format(
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
 SIZE_SLUG = 's-1vcpu-1gb'
 USER_DATA = requests.get(
-    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/digitalocean/cloud-config.yaml'.format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)).text
-
+    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/providers/digitalocean/cloud-config.yaml'
+    .format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)
+).text
 
 # Droplet settings
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,4 +1,5 @@
 import os
+import requests
 
 # Update with the MeiliSearch version TAG you want to build the image with
 
@@ -12,101 +13,12 @@ SNAPSHOT_NAME = 'MeiliSearch-{}-Debian-10.3'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG)
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
 SIZE_SLUG = 's-1vcpu-1gb'
-PROVIDER_NAME = 'digitalocean'
+USER_DATA = requests.get(
+    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/digitalocean/cloud-config.yaml'.format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)).text
+
 
 # Droplet settings
 
 DROPLET_NAME = '{}-BUILD'.format(SNAPSHOT_NAME)
 DROPLET_TAGS = ['MARKETPLACE', 'AUTOBUILD']
 ENABLE_BACKUPS = False
-
-# Cloud-init
-
-USER_DATA = """
-#cloud-config
-
-package_update: true
-
-package_upgrade: true
-
-users:
-  - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
-  - name: root
-    shell: /bin/bash
-
-packages:  
-  - git
-  - curl
-  - ufw
-  - gcc
-  - make
-  - nginx
-  - certbot
-  - python-certbot-nginx
-
-write_files:
-  - path: /etc/systemd/system/meilisearch.service
-    content: |
-      [Unit]
-      Description=MeiliSearch
-      After=systemd-user-sessions.service
-
-      [Service]
-      Type=simple
-      ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env development
-      Environment='MEILI_SERVER_PROVIDER=digitalocean'
-
-      [Install]
-      WantedBy=default.target
-
-  - path: /etc/nginx/sites-enabled/meilisearch
-    content: |
-      server {{
-          listen 80 default_server;
-          listen [::]:80 default_server;
-
-          server_name _;
-
-          location / {{
-              proxy_pass  http://127.0.0.1:7700;
-          }}
-
-          client_max_body_size 100M;
-      }}
-  
-  - path: /etc/nginx/sites-enabled/default
-    content: |
-      # Empty file
-
-  - path: /etc/profile.d/00-aliases.sh
-    content: |
-      alias meilisearch-setup='sudo sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh'
-
-  - path: /etc/profile.d/01-auto-run.sh
-    content: |
-      meilisearch-setup
-
-runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/MeiliSearch/releases/download/{0}/meilisearch-linux-amd64
-  - chmod 755 /usr/bin/meilisearch
-  - systemctl enable meilisearch.service
-  - ufw --force enable
-  - ufw allow 'Nginx Full'
-  - ufw allow 'OpenSSH'
-  - rm -rf /var/log/*.log
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | bash -s {0}
-  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash
-  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash
-
-power_state:
-  mode: reboot
-  message: Bye Bye
-  timeout: 10
-  condition: True
-""".format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,15 +1,8 @@
 import os
-import requests
 
 # Update with the MeiliSearch version TAG you want to build the image with
 
 MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.19.0'
-
-# Update with the fingerprint of your own SSH key after uploading it to DigitalOcean Settings => Security
-
-SSH_KEYS_FINGERPRINTS = [
-    'd4:b1:a5:ce:10:01:27:14:44:aa:a9:8e:41:bd:39:bc'
-]
 
 # Script settings
 
@@ -20,12 +13,100 @@ SNAPSHOT_NAME = 'MeiliSearch-{}-Debian-10.3'.format(
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
 SIZE_SLUG = 's-1vcpu-1gb'
 PROVIDER_NAME = 'digitalocean'
-USER_DATA = requests.get(
-    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/cloud-config.yaml'.format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)).text.replace('unknown_provider', PROVIDER_NAME)
-
 
 # Droplet settings
 
 DROPLET_NAME = '{}-BUILD'.format(SNAPSHOT_NAME)
 DROPLET_TAGS = ['MARKETPLACE', 'AUTOBUILD']
 ENABLE_BACKUPS = False
+
+# Cloud-init
+
+USER_DATA = """
+#cloud-config
+
+package_update: true
+
+package_upgrade: true
+
+users:
+  - default
+  - name: meilisearch
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    ssh_import_id: root
+    lock_passwd: True
+    shell: /bin/bash
+    groups: [sudo]
+  - name: root
+    shell: /bin/bash
+
+packages:  
+  - git
+  - curl
+  - ufw
+  - gcc
+  - make
+  - nginx
+  - certbot
+  - python-certbot-nginx
+
+write_files:
+  - path: /etc/systemd/system/meilisearch.service
+    content: |
+      [Unit]
+      Description=MeiliSearch
+      After=systemd-user-sessions.service
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env development
+      Environment='MEILI_SERVER_PROVIDER=digitalocean'
+
+      [Install]
+      WantedBy=default.target
+
+  - path: /etc/nginx/sites-enabled/meilisearch
+    content: |
+      server {{
+          listen 80 default_server;
+          listen [::]:80 default_server;
+
+          server_name _;
+
+          location / {{
+              proxy_pass  http://127.0.0.1:7700;
+          }}
+
+          client_max_body_size 100M;
+      }}
+  
+  - path: /etc/nginx/sites-enabled/default
+    content: |
+      # Empty file
+
+  - path: /etc/profile.d/00-aliases.sh
+    content: |
+      alias meilisearch-setup='sudo sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh'
+
+  - path: /etc/profile.d/01-auto-run.sh
+    content: |
+      meilisearch-setup
+
+runcmd:
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/MeiliSearch/releases/download/{0}/meilisearch-linux-amd64
+  - chmod 755 /usr/bin/meilisearch
+  - systemctl enable meilisearch.service
+  - ufw --force enable
+  - ufw allow 'Nginx Full'
+  - ufw allow 'OpenSSH'
+  - rm -rf /var/log/*.log
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | bash -s {0}
+  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/img_check.sh | bash
+  - curl https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/cleanup.sh | bash
+
+power_state:
+  mode: reboot
+  message: Bye Bye
+  timeout: 10
+  condition: True
+""".format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)


### PR DESCRIPTION
closes #149 

This is the first draft for the removal of the ssh commands.
See #149

It aims to :
- Simplify the whole process
- Have the same structure in all the meilisearch-cloud repositories
- Easier implementation of the future tests/CI
- Make the maintenance easier

What has been done :
- Remove the ssh commands launched after the droplet creation
- Remove the SSH_KEYS_FINGERPRINTS
- cloud-config.yaml is now unique for each repository (not in cloud-scripts anymore) and directly put in USER_DATA

To do :
- Test
- Update contributing
- @eskombro would you prefer the cloud-config.yaml to be an independant file instead of a variable USER_DATA in config.py?