### PR TITLE
Fix CI

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -85,7 +85,6 @@ def wait_for_droplet_power_off(droplet):
                         return
                     if act.status == 'errored':
                         destroy_droplet_and_exit(droplet)
-                        return
             time.sleep(4)
     except Exception as err:
         print('   Exception: {}'.format(err))

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -97,7 +97,7 @@ def power_off_droplet(droplet):
         wait_for_droplet_power_off(droplet)
     except Exception as err:
         print('   Exception: {}'.format(err))
-        destroy_droplet_and_exit(droplet)
+        raise
 
 def wait_for_snapshot_creation(droplet):
     try:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -64,11 +64,41 @@ def wait_for_droplet_shutdown(droplet):
                         act.type, act.status))
                     if act.status == 'completed':
                         return
+                    if act.status == 'errored':
+                        power_off_droplet(droplet)
+                        return
             time.sleep(4)
     except Exception as err:
         print('   Exception: {}'.format(err))
         raise
 
+def wait_for_droplet_power_off(droplet):
+    try:
+        actions = droplet.get_actions()
+        while True:
+            for act in actions:
+                if act.type == 'power_off':
+                    act.load()
+                    print('   Action {} is {}'.format(
+                        act.type, act.status))
+                    if act.status == 'completed':
+                        return
+                    if act.status == 'errored':
+                        destroy_droplet_and_exit(droplet)
+                        return
+            time.sleep(4)
+    except Exception as err:
+        print('   Exception: {}'.format(err))
+        raise
+
+def power_off_droplet(droplet):
+    print('Powering down droplet with power_off...')
+    try:
+        power_off = droplet.power_off(return_dict=True)
+        wait_for_droplet_power_off(droplet)
+    except Exception as err:
+        print('   Exception: {}'.format(err))
+        destroy_droplet_and_exit(droplet)
 
 def wait_for_snapshot_creation(droplet):
     try:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -94,7 +94,7 @@ def wait_for_droplet_power_off(droplet):
 def power_off_droplet(droplet):
     print('Powering down droplet with power_off...')
     try:
-        power_off = droplet.power_off(return_dict=True)
+        droplet.power_off(return_dict=True)
         wait_for_droplet_power_off(droplet)
     except Exception as err:
         print('   Exception: {}'.format(err))


### PR DESCRIPTION
Droplet shutdown failed and return `errored`
Add power_off in case of Droplet shutdown return `errored`