### PR TITLE
Add droplet IP verification and update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
       REQUEST_TIMEOUT_ENV_VAR: 30
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: pip3 install -r requirements.txt
     - name: Set image name as env variable
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Install dependencies
         run: pip3 install -r requirements.txt
       - name: Linter with pylint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,11 @@ jobs:
       DIGITALOCEAN_ACCESS_TOKEN: ${{secrets.DIGITALOCEAN_ACCESS_TOKEN}}
       REQUEST_TIMEOUT_ENV_VAR: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: pip3 install -r requirements.txt
     - name: Set image name as env variable
@@ -41,11 +41,11 @@ jobs:
     name: pylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: pip3 install -r requirements.txt
       - name: Linter with pylint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,10 @@ jobs:
       REQUEST_TIMEOUT_ENV_VAR: 30
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: pip3 install -r requirements.txt
     - name: Set image name as env variable
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: pip3 install -r requirements.txt
       - name: Linter with pylint

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -43,7 +43,7 @@ IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
-    print('   Timeout waiting for IP check')
+    print('   Timeout waiting for the IP address of the droplet')
     destroy_droplet_and_exit(droplet)
 
 print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -38,8 +38,10 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
+TIMEOUT=600
+
 print('Waiting until the droplet has an IP address')
-IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
@@ -51,7 +53,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=TIMEOUT)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -20,7 +20,7 @@ print('Creating droplet...')
 
 droplet = digitalocean.Droplet(token=conf.DIGITALOCEAN_ACCESS_TOKEN,
                                name=conf.DROPLET_NAME,
-                               region='lon1',  # London
+                               region='nyc1',  # New York
                                image='debian-10-x64',  # Debian 10.3
                                size_slug=conf.SIZE_SLUG,
                                tags=['marketplace'],

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -1,6 +1,5 @@
 import sys
 import digitalocean
-import time
 from utils import wait_for_droplet_creation, wait_for_health_check, \
     wait_for_droplet_shutdown, wait_for_snapshot_creation, \
     destroy_droplet_and_exit, check_meilisearch_version, STATUS_OK, \
@@ -53,7 +52,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=1000)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -38,10 +38,8 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-TIMEOUT=600
-
 print('Waiting until the droplet has an IP address')
-IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT)
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
@@ -53,7 +51,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=TIMEOUT)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -38,7 +38,7 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-print('Waiting for ip address from droplet')
+print('Waiting until the droplet has an IP address')
 IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -20,7 +20,7 @@ print('Creating droplet...')
 
 droplet = digitalocean.Droplet(token=conf.DIGITALOCEAN_ACCESS_TOKEN,
                                name=conf.DROPLET_NAME,
-                               region='nyc1',  # New York
+                               region='lon1', # London
                                image='debian-10-x64',  # Debian 10.3
                                size_slug=conf.SIZE_SLUG,
                                tags=['marketplace'],
@@ -33,6 +33,9 @@ droplet.create()
 try:
     wait_for_droplet_creation(droplet)
     droplet = droplet.load()
+    while droplet.ip_address == None:
+        print("No IP address")
+        droplet = droplet.load()
 except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
@@ -42,7 +45,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=3000)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -52,7 +52,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=1000)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -42,7 +42,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes: config and reboot)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=3000)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -38,14 +38,13 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-if droplet.load().ip_address is None:
-    print('Waiting for ip address from droplet')
-    IP = wait_for_droplet_ip(droplet, timeout_seconds=600)
-    if IP == STATUS_OK:
-        print(f'   Droplet IP: {droplet.ip_address}')
-    else:
-        print('   Timeout waiting for IP check')
-        destroy_droplet_and_exit(droplet)
+print('Waiting for ip address from droplet')
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
+if IP_AVAILABLE == STATUS_OK:
+    print(f'   Droplet IP: {droplet.ip_address}')
+else:
+    print('   Timeout waiting for IP check')
+    destroy_droplet_and_exit(droplet)
 
 print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -3,7 +3,7 @@ import requests
 
 # Update with the Meilisearch version TAG you want to build the image with
 
-MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.27.1'
+MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.28.1'
 
 # Script settings
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -11,7 +11,7 @@ DIGITALOCEAN_ACCESS_TOKEN = os.getenv('DIGITALOCEAN_ACCESS_TOKEN')
 DIGITALOCEAN_END_POINT = 'https://api.digitalocean.com/v2'
 SNAPSHOT_NAME = f'MeiliSearch-{MEILI_CLOUD_SCRIPTS_VERSION_TAG}-Debian-10.3'
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
-SIZE_SLUG = 's-6vcpu-16gb'
+SIZE_SLUG = 's-1vcpu-1gb'
 USER_DATA = requests.get(
     f'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{MEILI_CLOUD_SCRIPTS_VERSION_TAG}/scripts/providers/digitalocean/cloud-config.yaml'
 ).text

--- a/tools/config.py
+++ b/tools/config.py
@@ -11,7 +11,7 @@ DIGITALOCEAN_ACCESS_TOKEN = os.getenv('DIGITALOCEAN_ACCESS_TOKEN')
 DIGITALOCEAN_END_POINT = 'https://api.digitalocean.com/v2'
 SNAPSHOT_NAME = f'MeiliSearch-{MEILI_CLOUD_SCRIPTS_VERSION_TAG}-Debian-10.3'
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
-SIZE_SLUG = 's-1vcpu-1gb'
+SIZE_SLUG = 's-6vcpu-16gb'
 USER_DATA = requests.get(
     f'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{MEILI_CLOUD_SCRIPTS_VERSION_TAG}/scripts/providers/digitalocean/cloud-config.yaml'
 ).text

--- a/tools/config.py
+++ b/tools/config.py
@@ -3,7 +3,7 @@ import requests
 
 # Update with the Meilisearch version TAG you want to build the image with
 
-MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.28.1'
+MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.27.1'
 
 # Script settings
 

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -31,7 +31,7 @@ if MEILI_IMG is None:
 
 droplet = digitalocean.Droplet(token=conf.DIGITALOCEAN_ACCESS_TOKEN,
                                name=conf.DROPLET_TEST_NAME,
-                               region='lon1',  # London
+                               region='nyc1',  # New York
                                image=MEILI_IMG.id,
                                size_slug=conf.SIZE_SLUG,
                                tags=['meisearch-digitalocean-ci'],

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -55,7 +55,7 @@ IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
-    print('   Timeout waiting for IP check')
+    print('   Timeout waiting for the IP address of the droplet')
     destroy_droplet_and_exit(droplet)
 
 print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -31,7 +31,7 @@ if MEILI_IMG is None:
 
 droplet = digitalocean.Droplet(token=conf.DIGITALOCEAN_ACCESS_TOKEN,
                                name=conf.DROPLET_TEST_NAME,
-                               region='nyc1',  # New York
+                               region='lon1', # London
                                image=MEILI_IMG.id,
                                size_slug=conf.SIZE_SLUG,
                                tags=['meisearch-digitalocean-ci'],

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -50,7 +50,7 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-print('Waiting for ip address from droplet')
+print('Waiting until the droplet has an IP address')
 IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -50,14 +50,13 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-if droplet.load().ip_address is None:
-    print('Waiting for ip address from droplet')
-    IP = wait_for_droplet_ip(droplet, timeout_seconds=600)
-    if IP == STATUS_OK:
-        print(f'   Droplet IP: {droplet.ip_address}')
-    else:
-        print('   Timeout waiting for IP check')
-        destroy_droplet_and_exit(droplet)
+print('Waiting for ip address from droplet')
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
+if IP_AVAILABLE == STATUS_OK:
+    print(f'   Droplet IP: {droplet.ip_address}')
+else:
+    print('   Timeout waiting for IP check')
+    destroy_droplet_and_exit(droplet)
 
 print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -50,10 +50,8 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
-TIMEOUT=600
-
 print('Waiting until the droplet has an IP address')
-IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT)
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
@@ -65,7 +63,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=TIMEOUT)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=600)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -50,8 +50,10 @@ except Exception as err:
     print(f'   Exception: {err}')
     destroy_droplet_and_exit(droplet)
 
+TIMEOUT=600
+
 print('Waiting until the droplet has an IP address')
-IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=600)
+IP_AVAILABLE = wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT)
 if IP_AVAILABLE == STATUS_OK:
     print(f'   Droplet IP: {droplet.ip_address}')
 else:
@@ -63,7 +65,7 @@ print(f'   Droplet created. IP: {droplet.ip_address}, ID: {droplet.id}')
 # Wait for Health check after configuration is finished
 
 print('Waiting for Health check (may take a few minutes)')
-HEALTH = wait_for_health_check(droplet, timeout_seconds=1000)
+HEALTH = wait_for_health_check(droplet, timeout_seconds=TIMEOUT)
 if HEALTH == STATUS_OK:
     print('   Instance is healthy')
 else:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,6 +21,16 @@ def wait_for_droplet_creation(droplet):
         print(f'   Exception: {err}')
         raise
 
+def wait_for_droplet_ip(droplet, timeout_seconds=None):
+    start_time = datetime.datetime.now()
+    while timeout_seconds is None \
+            or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
+        if droplet.load().ip_address is not None:
+            return STATUS_OK
+        else:
+            time.sleep(2)
+    return STATUS_TIMEOUT
+
 def wait_for_health_check(droplet, timeout_seconds=None):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -5,6 +5,7 @@ import requests
 
 STATUS_OK = 0
 STATUS_TIMEOUT = 1
+TIMEOUT=600
 
 def wait_for_droplet_creation(droplet):
     try:
@@ -21,19 +22,17 @@ def wait_for_droplet_creation(droplet):
         print(f'   Exception: {err}')
         raise
 
-def wait_for_droplet_ip(droplet, timeout_seconds=None):
+def wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT):
     start_time = datetime.datetime.now()
-    while timeout_seconds is None \
-            or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
+    while check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
         if droplet.load().ip_address is not None:
             return STATUS_OK
         time.sleep(2)
     return STATUS_TIMEOUT
 
-def wait_for_health_check(droplet, timeout_seconds=None):
+def wait_for_health_check(droplet, timeout_seconds=TIMEOUT):
     start_time = datetime.datetime.now()
-    while timeout_seconds is None \
-            or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
+    while check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
         try:
             resp = requests.get(
                 f'http://{droplet.ip_address}/health', verify=False, timeout=10)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,7 +21,7 @@ def wait_for_droplet_creation(droplet):
         print(f'   Exception: {err}')
         raise
 
-def wait_for_droplet_ip(droplet, timeout_seconds=1000):
+def wait_for_droplet_ip(droplet, timeout_seconds=None):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \
             or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
@@ -30,7 +30,7 @@ def wait_for_droplet_ip(droplet, timeout_seconds=1000):
         time.sleep(2)
     return STATUS_TIMEOUT
 
-def wait_for_health_check(droplet, timeout_seconds=1000):
+def wait_for_health_check(droplet, timeout_seconds=None):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \
             or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -37,7 +37,7 @@ def wait_for_health_check(droplet, timeout_seconds=None):
         try:
             resp = requests.get(
                 f'http://{droplet.ip_address}/health', verify=False, timeout=10)
-            print(f'    Response: {resp}')
+            print(f'    Response: {resp}, IP: {droplet.ip_address}')
             if resp.status_code >= 200 and resp.status_code < 300:
                 return STATUS_OK
         except Exception:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -5,7 +5,6 @@ import requests
 
 STATUS_OK = 0
 STATUS_TIMEOUT = 1
-TIMEOUT=600
 
 def wait_for_droplet_creation(droplet):
     try:
@@ -22,7 +21,7 @@ def wait_for_droplet_creation(droplet):
         print(f'   Exception: {err}')
         raise
 
-def wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT):
+def wait_for_droplet_ip(droplet, timeout_seconds=None):
     start_time = datetime.datetime.now()
     if timeout_seconds is None:
         print('   Timeout cannot be null')
@@ -33,7 +32,7 @@ def wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT):
         time.sleep(2)
     return STATUS_TIMEOUT
 
-def wait_for_health_check(droplet, timeout_seconds=TIMEOUT):
+def wait_for_health_check(droplet, timeout_seconds=None):
     start_time = datetime.datetime.now()
     if timeout_seconds is None:
         print('   Timeout cannot be null')

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -28,6 +28,7 @@ def wait_for_health_check(droplet, timeout_seconds=None):
         try:
             resp = requests.get(
                 f'http://{droplet.ip_address}/health', verify=False, timeout=10)
+            print(f'    Response: {resp}')
             if resp.status_code >= 200 and resp.status_code < 300:
                 return STATUS_OK
         except Exception:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -30,7 +30,7 @@ def wait_for_droplet_ip(droplet, timeout_seconds=1000):
         time.sleep(2)
     return STATUS_TIMEOUT
 
-def wait_for_health_check(droplet, timeout_seconds=None):
+def wait_for_health_check(droplet, timeout_seconds=1000):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \
             or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,7 +21,7 @@ def wait_for_droplet_creation(droplet):
         print(f'   Exception: {err}')
         raise
 
-def wait_for_droplet_ip(droplet, timeout_seconds=None):
+def wait_for_droplet_ip(droplet, timeout_seconds=1000):
     start_time = datetime.datetime.now()
     while timeout_seconds is None \
             or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -27,8 +27,7 @@ def wait_for_droplet_ip(droplet, timeout_seconds=None):
             or check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
         if droplet.load().ip_address is not None:
             return STATUS_OK
-        else:
-            time.sleep(2)
+        time.sleep(2)
     return STATUS_TIMEOUT
 
 def wait_for_health_check(droplet, timeout_seconds=None):

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -24,6 +24,9 @@ def wait_for_droplet_creation(droplet):
 
 def wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT):
     start_time = datetime.datetime.now()
+    if timeout_seconds is None:
+        print('   Timeout cannot be null')
+        return STATUS_TIMEOUT
     while check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
         if droplet.load().ip_address is not None:
             return STATUS_OK
@@ -32,6 +35,9 @@ def wait_for_droplet_ip(droplet, timeout_seconds=TIMEOUT):
 
 def wait_for_health_check(droplet, timeout_seconds=TIMEOUT):
     start_time = datetime.datetime.now()
+    if timeout_seconds is None:
+        print('   Timeout cannot be null')
+        return STATUS_TIMEOUT
     while check_timeout(start_time, timeout_seconds) is not STATUS_TIMEOUT:
         try:
             resp = requests.get(

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -37,7 +37,7 @@ def wait_for_health_check(droplet, timeout_seconds=1000):
         try:
             resp = requests.get(
                 f'http://{droplet.ip_address}/health', verify=False, timeout=10)
-            print(f'    Response: {resp}, IP: {droplet.ip_address}')
+            print(f'    Droplet health: {resp}, IP: {droplet.ip_address}')
             if resp.status_code >= 200 and resp.status_code < 300:
                 return STATUS_OK
         except Exception:


### PR DESCRIPTION
The purpose of this PR is to fix the recurrent issue we had with the CI who was failing.
Sometimes it happens that the IP of the droplet wasn't loaded so the check of the instance was not possible like in this [action](https://github.com/meilisearch/meilisearch-digitalocean/actions/runs/3173793574/jobs/5169803173)
A check of the fact that the IP was available before the rest of the script has been added.