### PR TITLE
Fix github env variable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,12 +30,12 @@ jobs:
     - name: Set image name as env variable
       run: echo "IMAGE_NAME=meilisearch_digitalocean_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
     - name: Build image
-      run: python3 tools/build_image.py $IMAGE_NAME --no-analytics
+      run: python3 tools/build_image.py ${{ env.IMAGE_NAME }} --no-analytics
     - name: Test image
-      run: python3 tools/test_image.py $IMAGE_NAME
+      run: python3 tools/test_image.py ${{ env.IMAGE_NAME }}
     - name: Clean image
       if: ${{ always() }}
-      run: python3 tools/destroy_image.py $IMAGE_NAME
+      run: python3 tools/destroy_image.py ${{ env.IMAGE_NAME }}
 
   pylint:
     name: pylint


### PR DESCRIPTION
The secret credentials have become unavailable in the GitHub action for an unknown reason this PR seems to repair this problem.