### PR TITLE
Changes related to the next Meilisearch release (v0.29.1)

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -22,7 +22,7 @@ print('Creating droplet...')
 droplet = digitalocean.Droplet(token=conf.DIGITALOCEAN_ACCESS_TOKEN,
                                name=conf.DROPLET_NAME,
                                region='lon1',  # London
-                               image='ubuntu-20-04-x64',  # Ubuntu 20.04
+                               image='debian-10-x64', # Debian 10.3
                                size_slug=conf.SIZE_SLUG,
                                tags=['marketplace'],
                                backups=conf.ENABLE_BACKUPS,

--- a/tools/config.py
+++ b/tools/config.py
@@ -3,13 +3,13 @@ import requests
 
 # Update with the Meilisearch version TAG you want to build the image with
 
-MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.29.0'
+MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.29.1'
 
 # Script settings
 
 DIGITALOCEAN_ACCESS_TOKEN = os.getenv('DIGITALOCEAN_ACCESS_TOKEN')
 DIGITALOCEAN_END_POINT = 'https://api.digitalocean.com/v2'
-SNAPSHOT_NAME = f'MeiliSearch-{MEILI_CLOUD_SCRIPTS_VERSION_TAG}-Ubuntu-20.04'
+SNAPSHOT_NAME = f'MeiliSearch-{MEILI_CLOUD_SCRIPTS_VERSION_TAG}-Debian-10.3'
 # https://developers.digitalocean.com/documentation/changelog/api-v2/new-size-slugs-for-droplet-plan-changes/
 SIZE_SLUG = 's-2vcpu-2gb'
 USER_DATA = requests.get(


### PR DESCRIPTION
Due to this [issue](https://github.com/meilisearch/meilisearch/issues/2850) the DO image was switched to ubuntu20.04.
It has been corrected since then, so the image is back on Debian [see](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.1)